### PR TITLE
Freeze STC in paused on both streams

### DIFF
--- a/recipes-multimedia/gstreamer-wpe/files/gstreamer1.0-wpe-plugins-brcm/0004-BCMCZ-375-Freeze-STC-regardless-of-the-client.patch
+++ b/recipes-multimedia/gstreamer-wpe/files/gstreamer1.0-wpe-plugins-brcm/0004-BCMCZ-375-Freeze-STC-regardless-of-the-client.patch
@@ -1,0 +1,124 @@
+From 27cb81ff911104093f78240937398fa96025bcd1 Mon Sep 17 00:00:00 2001
+From: krp97 <k.plata@metrological.com>
+Date: Tue, 21 Dec 2021 14:17:21 +0000
+Subject: [PATCH] [BCMCZ-375] Freeze STC regardless of the client
+
+When commiting NULL -> PAUSED state change, playback starts
+playing depending on which streams STC is frozen.
+
+Ticket link:
+https://jira.rdkcentral.com/jira/browse/BCMCZ-375
+---
+ reference/audiosink/src/gst_brcm_audio_sink.c |  4 ++--
+ reference/util/src/gst_system_clock.c         | 21 ++++-----------------
+ reference/util/src/gst_system_clock.h         |  3 +--
+ reference/videosink/src/gst_brcm_video_sink.c |  4 ++--
+ 4 files changed, 9 insertions(+), 23 deletions(-)
+
+diff --git a/reference/audiosink/src/gst_brcm_audio_sink.c b/reference/audiosink/src/gst_brcm_audio_sink.c
+index a6894d8..f1806c4 100755
+--- a/reference/audiosink/src/gst_brcm_audio_sink.c
++++ b/reference/audiosink/src/gst_brcm_audio_sink.c
+@@ -1088,7 +1088,7 @@ void audio_sink_nexus_pause(Gstbrcmaudiosink *sink, int rate)
+ 
+     if (!rate) {
+         /* freeze stc before decoder changes */
+-        gst_brcm_system_clock_freeze_stc_channel(sink->stc_channel, SYS_CLK_CLIENT_AUDIO, !rate);
++        gst_brcm_system_clock_freeze_stc_channel(sink->stc_channel, !rate);
+     }
+ 
+     NEXUS_SimpleStcChannel_GetSettings(sink->stc_channel, &stcSettings);
+@@ -1107,7 +1107,7 @@ void audio_sink_nexus_pause(Gstbrcmaudiosink *sink, int rate)
+ 
+     if (rate) {
+         /* thaw stc after decoder changes */
+-        gst_brcm_system_clock_freeze_stc_channel(sink->stc_channel, SYS_CLK_CLIENT_AUDIO, !rate);
++        gst_brcm_system_clock_freeze_stc_channel(sink->stc_channel, !rate);
+     }
+ }
+ 
+diff --git a/reference/util/src/gst_system_clock.c b/reference/util/src/gst_system_clock.c
+index ce14076..06a71c2 100755
+--- a/reference/util/src/gst_system_clock.c
++++ b/reference/util/src/gst_system_clock.c
+@@ -174,7 +174,7 @@ unsigned int gst_brcm_system_clock_get_stc_channel_info(NEXUS_SimpleStcChannelHa
+     return val;
+ }
+ 
+-void gst_brcm_system_clock_freeze_stc_channel(NEXUS_SimpleStcChannelHandle stc_channel, SYS_CLK_CLIENT sys_clk_client, bool freeze)
++void gst_brcm_system_clock_freeze_stc_channel(NEXUS_SimpleStcChannelHandle stc_channel, bool freeze)
+ {
+     unsigned int token_id;
+     int i;
+@@ -193,22 +193,9 @@ void gst_brcm_system_clock_freeze_stc_channel(NEXUS_SimpleStcChannelHandle stc_c
+     if (i==MAX_STC_CHANNELS) {
+         BDBG_WRN(("Stc channel not found"));
+     } else {
+-        if (freeze) {
+-            if (!sysclock.clock[token_id].frozen[SYS_CLK_CLIENT_VIDEO] && !sysclock.clock[token_id].frozen[SYS_CLK_CLIENT_AUDIO]){
+-                NEXUS_Error rc = NEXUS_SimpleStcChannel_Freeze(stc_channel, true);
+-                if (rc) {
+-                    BDBG_WRN(("NEXUS_SimpleStcChannel_Freeze failed %d", GST_FUNCTION,__LINE__, rc));
+-                }
+-            }
+-            sysclock.clock[token_id].frozen[sys_clk_client] = true;
+-        } else { /* freeze == 0 */
+-            sysclock.clock[token_id].frozen[sys_clk_client] = false;
+-            if (!sysclock.clock[token_id].frozen[SYS_CLK_CLIENT_VIDEO] && !sysclock.clock[token_id].frozen[SYS_CLK_CLIENT_AUDIO]){
+-                NEXUS_Error rc = NEXUS_SimpleStcChannel_Freeze(stc_channel, false);
+-                if (rc) {
+-                    BDBG_WRN(("NEXUS_SimpleStcChannel_Freeze failed %d", GST_FUNCTION,__LINE__, rc));
+-                }
+-            }
++        NEXUS_Error rc = NEXUS_SimpleStcChannel_Freeze(stc_channel, freeze);
++        if (rc) {
++            BDBG_WRN(("NEXUS_SimpleStcChannel_Freeze failed %d", GST_FUNCTION,__LINE__, rc));
+         }
+     }
+     BRCM_G_MUTEX_UNLOCK(clock_mutex);
+diff --git a/reference/util/src/gst_system_clock.h b/reference/util/src/gst_system_clock.h
+index 6486921..7490781 100644
+--- a/reference/util/src/gst_system_clock.h
++++ b/reference/util/src/gst_system_clock.h
+@@ -60,7 +60,6 @@ typedef struct SystemClock {
+     NEXUS_SimpleStcChannelHandle stc_channel;
+     unsigned int token;
+     unsigned int ref_count;
+-    bool frozen[SYS_CLK_CLIENT_MAX];
+ }Clock;
+ 
+ struct _GstBrcmSystemClock {
+@@ -72,7 +71,7 @@ struct _GstBrcmSystemClock {
+ unsigned long gst_brcm_system_clock_acquire_stc_channel(unsigned int token);
+ void gst_brcm_system_clock_release_stc_channel(NEXUS_SimpleStcChannelHandle stc_channel);
+ unsigned int gst_brcm_system_clock_get_stc_channel_info(NEXUS_SimpleStcChannelHandle stc_channel);
+-void gst_brcm_system_clock_freeze_stc_channel(NEXUS_SimpleStcChannelHandle stc_channel, SYS_CLK_CLIENT sys_clk_client, bool freeze /* if true, the STC stops. if false, the STC starts. */);
++void gst_brcm_system_clock_freeze_stc_channel(NEXUS_SimpleStcChannelHandle stc_channel, bool freeze /* if true, the STC stops. if false, the STC starts. */);
+ 
+ #endif
+ 
+diff --git a/reference/videosink/src/gst_brcm_video_sink.c b/reference/videosink/src/gst_brcm_video_sink.c
+index 10a9eb7..e4f1fd6 100755
+--- a/reference/videosink/src/gst_brcm_video_sink.c
++++ b/reference/videosink/src/gst_brcm_video_sink.c
+@@ -646,7 +646,7 @@ void video_sink_nexus_pause(Gstbrcmvideosink *sink, int rate)
+ 
+     if (!rate) {
+         /* freeze stc before decoder changes */
+-        gst_brcm_system_clock_freeze_stc_channel(sink->stc_channel, SYS_CLK_CLIENT_VIDEO, !rate);
++        gst_brcm_system_clock_freeze_stc_channel(sink->stc_channel, !rate);
+     }
+ 
+     NEXUS_VideoDecoderTrickState ts;
+@@ -663,7 +663,7 @@ void video_sink_nexus_pause(Gstbrcmvideosink *sink, int rate)
+ 
+     if (rate) {
+         /* thaw after decoder changes */
+-        gst_brcm_system_clock_freeze_stc_channel(sink->stc_channel, SYS_CLK_CLIENT_VIDEO, !rate);
++        gst_brcm_system_clock_freeze_stc_channel(sink->stc_channel, !rate);
+     }
+ 
+ }
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer-wpe/gstreamer1.0-wpe-plugins-brcm_git.bbappend
+++ b/recipes-multimedia/gstreamer-wpe/gstreamer1.0-wpe-plugins-brcm_git.bbappend
@@ -11,6 +11,7 @@ SRC_URI_append = " \
     file://0001-Do-not-minimize-composition-on-decoder-startup.patch \
     file://0002-Revert-BCMCZ-121-remove-gstsvpmeta.h.patch \
     file://0003-Configure-sinks-to-use-the-async-mode.patch \
+    file://0004-BCMCZ-375-Freeze-STC-regardless-of-the-client.patch \
 "
 
 SRCREV = "5534aa56dfea8d3758db59753c539f0be1dba03d"


### PR DESCRIPTION
When commiting NULL -> PAUSED state change, playback starts
playing depending on which streams STC is frozen.

Ticket link:
https://jira.rdkcentral.com/jira/browse/BCMCZ-375