### PR TITLE
Do not reset position on the first frame

### DIFF
--- a/recipes-multimedia/gstreamer-wpe/files/gstreamer1.0-wpe-plugins-brcm/0006-BCMCZ-377-Do-not-reset-position-on-first-frame.patch
+++ b/recipes-multimedia/gstreamer-wpe/files/gstreamer1.0-wpe-plugins-brcm/0006-BCMCZ-377-Do-not-reset-position-on-first-frame.patch
@@ -1,0 +1,56 @@
+From 7c23b19945bc218f2c40e94def1330e50275b38a Mon Sep 17 00:00:00 2001
+From: "k.plata" <k.plata@metrological.com>
+Date: Mon, 31 Jan 2022 14:09:01 +0000
+Subject: [PATCH] BCMCZ-377: Do not reset position on first frame
+
+This commit removes resetting the decoder->position variable in
+picture_ready_cb. If an application was querying the position
+between a first decoded pts and first displayed pts, it would
+receive the 0 pts, even though the start pts could be different.
+
+Current behavior leaves the decoder->position at a value set when
+handling the GST_EVENT_SEGMENT. This makes sure that the video
+decoder returns a segment start PTS, before it receives a first
+displayed frame.
+---
+ reference/videodecode/src/gst_brcm_video_decoder.c | 15 +++------------
+ 1 file changed, 3 insertions(+), 12 deletions(-)
+
+diff --git a/reference/videodecode/src/gst_brcm_video_decoder.c b/reference/videodecode/src/gst_brcm_video_decoder.c
+index b577123..80e05ea 100755
+--- a/reference/videodecode/src/gst_brcm_video_decoder.c
++++ b/reference/videodecode/src/gst_brcm_video_decoder.c
+@@ -1396,20 +1396,10 @@ static void  picture_ready_cb(void *ctx, int p) {
+ 
+             /*gst_brcm_system_debug_print(1,"First Pic Decoded");*/
+             brcm_asyncthread_signal_emit(decoder->brcm_async, G_OBJECT (decoder), first_video_frame_signal, 0, 2, NULL);
+-
+-            BRCM_G_MUTEX_LOCK(decoder->mutex);
+-            decoder->current_pts = decoderStatus.pts;
+-            decoder->current_pts_valid = TRUE;
+-            decoder->position = 0;
+-            decoder->position_keeper = 0;
+-            decoder->disco_adjust_pts = 0;
+-            decoder->ignore_disco = FALSE;
+-        }
+-        else
+-        {
+-            BRCM_G_MUTEX_LOCK(decoder->mutex);
+         }
+ 
++        BRCM_G_MUTEX_LOCK(decoder->mutex);
++
+         if (decoderStatus.numDisplayed) {  /* decoder will not display until start PTS is achieved, so this will prevent "reverse" position calculations */
+             if (!decoder->first_pts_valid) {
+                 decoder->first_pts_valid = TRUE;
+@@ -1419,6 +1409,7 @@ static void  picture_ready_cb(void *ctx, int p) {
+             }
+             video_update_pts_vars(decoder, decoderStatus.pts);
+         }
++
+         decoder->num_pics_decoded++;
+         decoder->src_width = decoderStatus.source.width;
+         decoder->src_height = decoderStatus.source.height;
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer-wpe/gstreamer1.0-wpe-plugins-brcm_git.bbappend
+++ b/recipes-multimedia/gstreamer-wpe/gstreamer1.0-wpe-plugins-brcm_git.bbappend
@@ -13,6 +13,7 @@ SRC_URI_append = " \
     file://0003-Configure-sinks-to-use-the-async-mode.patch \
     file://0004-BCMCZ-368-SWRDKV-3139-Gravity-UI-can-t-play-web-vide.patch \
     file://0005-BCMCZ-376-Don-t-flush-on-new-segment-event.patch \
+    file://0006-BCMCZ-377-Do-not-reset-position-on-first-frame.patch \
 "
 
 SRCREV = "5534aa56dfea8d3758db59753c539f0be1dba03d"


### PR DESCRIPTION
This commit removes resetting the decoder->position variable 
in picture_ready_cb. If an application was querying the position
between a first decoded pts and first displayed pts, it would
receive the 0 pts, even though the start pts could be different.

Current behavior leaves the decoder->position at a value set when
handling the GST_EVENT_SEGMENT. This makes sure that the video
decoder returns a segment start PTS, before it receives a first
displayed frame.

https://jira.rdkcentral.com/jira/browse/BCMCZ-377
