### PR TITLE
Respond to position queries after a segment event

### DIFF
--- a/recipes-multimedia/gstreamer-wpe/files/gstreamer1.0-wpe-plugins-brcm/0007-BCMCZ-379-Refactor-position-query-handling.patch
+++ b/recipes-multimedia/gstreamer-wpe/files/gstreamer1.0-wpe-plugins-brcm/0007-BCMCZ-379-Refactor-position-query-handling.patch
@@ -1,0 +1,209 @@
+From 7df5b7606158dc73cea14936500bb722f4c4973b Mon Sep 17 00:00:00 2001
+From: "k.plata" <k.plata@metrological.com>
+Date: Mon, 14 Feb 2022 08:12:57 +0000
+Subject: [PATCH] BCMCZ-379 Refactor position query handling
+
+This commit refactors position query handling in the video decoder,
+with the following changes:
+  - recalculate_position function is removed, in favour of using
+    a generic gstreamer function (`gst_segment_to_stream_time`),
+  - query_position function is reworked, so that it now uses
+    `gst_segment_to_stream_time` for absolute position calculation,
+  - formatting fixes to break up long lines of code.
+
+These changes also address an issue, where the video decoder did not
+respond to position queries for a prolonged time during startup.
+A position query should be handled, as soon as a segment event has
+been processed.
+---
+ reference/videodecode/src/gst_brcm_video_decoder.c | 94 ++++++++++++----------
+ reference/videodecode/src/gst_brcm_video_decoder.h |  1 +
+ 2 files changed, 53 insertions(+), 42 deletions(-)
+
+diff --git a/reference/videodecode/src/gst_brcm_video_decoder.c b/reference/videodecode/src/gst_brcm_video_decoder.c
+index 1cf7118..897d746 100755
+--- a/reference/videodecode/src/gst_brcm_video_decoder.c
++++ b/reference/videodecode/src/gst_brcm_video_decoder.c
+@@ -505,11 +505,6 @@ static void gst_brcm_video_decoder_class_init (GstBrcmVideoDecoderClass *klass)
+ // need to be enabled to make videoplane zorder to work.
+ #define SET_GRAPHIC_SURFACE 0
+ 
+-static gint64 recalculate_position(GstBrcmVideoDecoder *decoder)
+-{
+-    return decoder->start_position + decoder->position * decoder->applied_rate;
+-}
+-
+ static void complete2(void *context, int param)
+ {
+     BSTD_UNUSED(param);
+@@ -782,7 +777,7 @@ static void gst_brcm_video_decoder_init(GstBrcmVideoDecoder *decoder) {
+     decoder->forward_disco_threshold_pts = VID_FORWARD_DISCONTINUITY_THRESHOLD_PTS;
+     decoder->enable_vsync_mode = FALSE;
+     decoder->treat_iframe_as_rap = FALSE;
+-
++    decoder->current_segment = NULL;
+ 
+     decoder->enable_limit_buffering = FALSE;
+     decoder->verify_decode_timer = 0;
+@@ -797,7 +792,6 @@ static void gst_brcm_video_decoder_init(GstBrcmVideoDecoder *decoder) {
+     decoder->enable_cc_passthru = TRUE;
+     decoder->decoder_type_pip = FALSE;
+     decoder->mosaic = FALSE;
+-    decoder->applied_rate = 1;
+     decoder->ignore_disco_during_trick = FALSE;
+     decoder->segment_rate = 1.0;
+ 
+@@ -1127,12 +1121,24 @@ static void video_update_pts_vars(GstBrcmVideoDecoder *decoder, unsigned int new
+         decoder->current_pts_valid = TRUE;
+ 
+         decoder->position = decoder->start_position + (((gint64)decoder->current_pts - ((gint64)decoder->first_pts + decoder->disco_adjust_pts)) * GST_MSECOND) / 45;
+-        GST_TRACE("current_pts=%ldms firstPts=%ldms disco_adjust_pts=%lldms delta=%ldms position=%llums start_position=%llums", decoder->current_pts/45, decoder->first_pts/45, decoder->disco_adjust_pts/45, (long int)(decoder->current_pts - (decoder->first_pts + decoder->disco_adjust_pts))/45, decoder->position/GST_MSECOND, decoder->start_position/GST_MSECOND);
++        
++        GST_TRACE("current_pts=%ldms firstPts=%ldms disco_adjust_pts=%lldms delta=%ldms position=%llums start_position=%llums"
++            , decoder->current_pts / 45
++            , decoder->first_pts / 45
++            , decoder->disco_adjust_pts / 45
++            , (long int)(decoder->current_pts - (decoder->first_pts + decoder->disco_adjust_pts)) / 45
++            , decoder->position / GST_MSECOND
++            , decoder->start_position / GST_MSECOND);
++        
+         if (ABS(decoder->position - decoder->position_keeper) >= ABS(decoder->position_timer * rate)) {
+-            GST_TRACE("rate: %f position: %"G_GINT64_FORMAT" diff: %"G_GINT64_FORMAT,
+-                    rate, recalculate_position(decoder), (decoder->position - decoder->position_keeper));
++            guint64 position = gst_segment_to_stream_time(decoder->current_segment, GST_FORMAT_TIME, decoder->position);
+             decoder->position_keeper = decoder->position;
+-            g_signal_emit (G_OBJECT (decoder), position_change_signal, 0, recalculate_position(decoder) , NULL);
++            g_signal_emit (G_OBJECT (decoder), position_change_signal, 0, position, NULL);
++
++            GST_TRACE("rate: %f position: %"G_GINT64_FORMAT" diff: %"G_GINT64_FORMAT
++                , rate
++                , position
++                , (decoder->position - decoder->position_keeper));
+         }
+     }
+ }
+@@ -2944,6 +2950,12 @@ static gboolean gst_brcm_video_decoder_sink_event(GstPad *pad, GstObject *parent
+         decoder->log_buffers_cnt = 0;
+         decoder->eos_seen = FALSE;
+         decoder->ignore_disco = TRUE;
++        
++        if(decoder->current_segment) {
++            gst_segment_free(decoder->current_segment);
++            decoder->current_segment = NULL;
++        }
++
+         stop_eos_timer(decoder, "GST_EVENT_FLUSH_START");
+         NEXUS_SimpleVideoDecoder_Flush(decoder->video_decoder);
+         decoder->num_pics_decoded = 0;
+@@ -2978,6 +2990,7 @@ static gboolean gst_brcm_video_decoder_sink_event(GstPad *pad, GstObject *parent
+         else
+             decoder->ignore_disco_during_trick = FALSE;
+ 
++        decoder->current_segment = gst_segment_copy(dataSegment);
+         decoder->applied_rate = applied_rate;
+         decoder->stop_position = segStop;
+         decoder->start_position = segStart;
+@@ -2987,8 +3000,13 @@ static gboolean gst_brcm_video_decoder_sink_event(GstPad *pad, GstObject *parent
+ 
+         if (segFormat == GST_FORMAT_TIME) {
+             uint32_t start_pts = (GST_TIME_AS_MSECONDS(segStart) * 45);
+-            GST_INFO("GST_EVENT_NEWSEGMENT start_pts 0x%x segStart %"G_GINT64_FORMAT"ms, segPos %"G_GINT64_FORMAT"ms ", start_pts, (segStart/GST_MSECOND), (segPos/GST_MSECOND));
+             NEXUS_SimpleVideoDecoder_SetStartPts(decoder->video_decoder, start_pts);
++            
++            GST_INFO("New segment - start: %"GST_TIME_FORMAT", position: %"GST_TIME_FORMAT", stop: %"GST_TIME_FORMAT", nexus decoder startPts: %u)"
++                , GST_TIME_ARGS(segStart)
++                , GST_TIME_ARGS(segPos)
++                , GST_TIME_ARGS(segStop)
++                , start_pts);
+         }
+ 
+         rv = gst_pad_push_event(decoder->src_pad, event);
+@@ -2996,15 +3014,16 @@ static gboolean gst_brcm_video_decoder_sink_event(GstPad *pad, GstObject *parent
+             GST_INFO("gst_pad_push_event- newsegment rv=%d, probably flushing", rv);
+         }
+ 
+-        GST_LOG("send buffer to sink to achieve preroll");   /* webkit, video decoder may not have new frame to send, if video filter is paused */
+-
+         if (!decoder->sw_sync_mode) {
++            GST_LOG("send buffer to sink to achieve preroll");   /* webkit, video decoder may not have new frame to send, if video filter is paused */
+             video_buffer_push(decoder);
+         }
+ 
+         gst_brcm_video_decoder_limiting_force_leave(decoder);
+-        g_signal_emit (G_OBJECT (decoder), position_change_signal, 0, recalculate_position(decoder) , NULL);
++        guint64 stream_time = gst_segment_to_stream_time(dataSegment, GST_FORMAT_TIME, decoder->position);
++        g_signal_emit (G_OBJECT (decoder), position_change_signal, 0, stream_time, NULL);
+         decoder->position_keeper = decoder->position;
++
+         break;
+     }
+     case GST_EVENT_EOS:
+@@ -3371,35 +3390,26 @@ static void gst_brcm_video_decoder_sink_unlink(GstPad *pad, GstObject *parent) {
+ }
+ 
+ static gboolean query_position(GstPad *pad, GstObject *parent, GstQuery *query) {
++    GstBrcmVideoDecoder *decoder = GST_BRCM_VIDEO_DECODER(parent);
++    GstFormat format;
++    gboolean rv = FALSE;
+ 
+-  GstBrcmVideoDecoder *decoder = GST_BRCM_VIDEO_DECODER(parent);
+-  GstFormat format;
+-  gboolean rv = FALSE;
+-
+-  gst_query_parse_position(query, &format, NULL);
+-  if(format == GST_FORMAT_BYTES)
+-      rv = gst_pad_query_default(pad, parent, query);
+-  else
+-  {
+-      gint64 position, duration;
+-      GstFormat fmt = GST_FORMAT_TIME;
+-      gboolean ret;
+-
+-      if (!decoder->num_pics_decoded) {   /* position info not valid */
+-          return FALSE;
+-      }
++    gst_query_parse_position(query, &format, NULL);
++    
++    if(format == GST_FORMAT_BYTES) {
++        rv = gst_pad_query_default(pad, parent, query);
++    } else if(decoder->current_segment != NULL) { 
++        guint64 position = gst_segment_to_stream_time(decoder->current_segment, GST_FORMAT_TIME, decoder->position);
++        gst_query_set_position(query, GST_FORMAT_TIME, position);
+ 
+-      position = decoder->start_position + (decoder->position - decoder->start_position) * decoder->applied_rate;
+-      if (decoder->applied_rate < 0) { /* reverse playback */
+-          ret = gst_pad_query_duration(pad,fmt,&duration);
+-          if (ret)
+-              position = decoder->stop_position + decoder->position*decoder->applied_rate;
+-      }
+-      gst_query_set_position(query, GST_FORMAT_TIME, position);
+-      GST_LOG("video_decoder: position %lldns (%lldms), decoder->start_position %lldns (%lldms), decoder->position %lldns (%lldms)", position, position/GST_MSECOND, decoder->start_position, decoder->start_position/GST_MSECOND, decoder->position, decoder->position/GST_MSECOND);
+-      rv = TRUE;
+-  }
+-  return rv;
++        GST_LOG("position: %"GST_TIME_FORMAT", segment start: %"GST_TIME_FORMAT", segment: %"GST_TIME_FORMAT""
++            , GST_TIME_ARGS(position)
++            , GST_TIME_ARGS(decoder->start_position)
++            , GST_TIME_ARGS(decoder->position));
++
++        rv = TRUE;
++    }
++    return rv;
+ }
+ 
+ static gboolean gst_brcm_video_decoder_src_query(GstPad *pad, GstObject *parent, GstQuery *query) {
+diff --git a/reference/videodecode/src/gst_brcm_video_decoder.h b/reference/videodecode/src/gst_brcm_video_decoder.h
+index 33d02c3..b1a5b89 100755
+--- a/reference/videodecode/src/gst_brcm_video_decoder.h
++++ b/reference/videodecode/src/gst_brcm_video_decoder.h
+@@ -158,6 +158,7 @@ struct _GstBrcmVideoDecoder
+     gint64 start_position;                      /* start position when applied_rate>1*/
+     gboolean ignore_disco_during_trick;         /* ignore looking for discontinuity during trick */
+     gdouble segment_rate;
++    GstSegment* current_segment;
+ 
+     GThread *worker;
+     BRCM_G_MUTEX mutex;
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer-wpe/gstreamer1.0-wpe-plugins-brcm_git.bbappend
+++ b/recipes-multimedia/gstreamer-wpe/gstreamer1.0-wpe-plugins-brcm_git.bbappend
@@ -14,6 +14,7 @@ SRC_URI_append = " \
     file://0004-BCMCZ-368-SWRDKV-3139-Gravity-UI-can-t-play-web-vide.patch \
     file://0005-BCMCZ-376-Don-t-flush-on-new-segment-event.patch \
     file://0006-BCMCZ-377-Do-not-reset-position-on-first-frame.patch \
+    file://0007-BCMCZ-379-Refactor-position-query-handling.patch \
 "
 
 SRCREV = "5534aa56dfea8d3758db59753c539f0be1dba03d"


### PR DESCRIPTION
This commit refactors position query handling in the video decoder,
with the following changes:
- recalculate_position function is removed, in favour of using
      a generic gstreamer function (`gst_segment_to_stream_time`),
- query_position function is reworked, so that it now uses
  `gst_segment_to_stream_time` for absolute position calculation,
- formatting fixes to break up long lines of code.

These changes also address an issue, where the video decoder did not
respond to position queries for a prolonged time during startup.
A position query should be handled, as soon as a segment event has
been processed.

https://jira.rdkcentral.com/jira/browse/BCMCZ-379